### PR TITLE
Fix print_conversation for single-item generation

### DIFF
--- a/src/qstn/inference/survey_inference.py
+++ b/src/qstn/inference/survey_inference.py
@@ -189,6 +189,7 @@ def batch_generation(
         _print_conversation(
             system_messages=system_messages,
             prompts=prompts,
+            assistant_messages=None,
             plain_results=plain_results,
             reasoning_output=reasoning_outputs,
             logprob_result=logprob_result,


### PR DESCRIPTION
Fixes a bug where `conduct_survey_single_item(print_conversation=True, ...)` throws a `TypeError`. This is fixed by passing `assistant_messages=None` when `_print_conversation()` is called for single-item generation.